### PR TITLE
Adding the Deck Assembler Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,10 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# User Added - Ignore the bin directory - These are files provided from elsewhere.
+bin
+cards
+cards-complete
+imageborder*
+saturation*

--- a/card_list.txt
+++ b/card_list.txt
@@ -1,0 +1,135 @@
+Runner	Corroder
+Runner	Demolition Run
+Runner	Data Dealer
+Runner	Singularity
+Runner	Akamatsu Mem Chip
+Runner	Imp
+Runner	Spinal Modem
+Runner	Darwin
+Corp	Stronger Together
+Corp	Ash 2X3ZB9CY
+Runner	Hemorrhage
+Corp	Caduceus
+Runner	Notoriety
+Corp	Replicating Perfection
+Corp	Fetal AI
+Corp	Trick of Light
+Runner	Emergency Shutdown
+Runner	Chaos Theory
+Runner	Forged Activation Orders
+Runner	Test Run
+Runner	Dinosaurus
+Runner	Doppelganger
+Corp	Marked Accounts
+Runner	Pheromones
+Runner	Scrubber
+Runner	Crash Space
+Runner	Fall Guy
+Runner	Mr. Li
+Runner	Deus X
+Corp	Oversight AI
+Runner	Indexing
+Runner	Xanadu
+Runner	Networking
+Runner	HQ Interface
+Runner	Kati Jones
+Corp	Hokusai Grid
+Runner	Retrieval Run
+Runner	Rabbit Hole
+Runner	The Personal Touch
+Runner	R_D Interface
+Runner	Magnum Opus
+Corp	Eli 1.0
+Corp	Ronin
+Runner	All-Nighter
+Runner	Sacrificial Construct
+Runner	Infiltration
+Corp	Flare
+Runner	Underworld Contact
+Corp	Project Ares
+Corp	Hudson 1.0
+Corp	Shipment from MirrorMorph
+Corp	Strongbox
+Runner	Quest Completed
+Corp	Blue Level Clearance
+Corp	Yagura
+Corp	Wraparound
+Corp	Whirlpool
+Corp	Lotus Field
+Runner	Lamprey
+Corp	Crisium Grid
+Runner	Quetzal - Free Spirit
+Corp	Reversed Accounts
+Corp	Blue Sun - Powering the Future
+Corp	Daily Business Show
+Runner	Leela Patel
+Runner	Career Fair
+Corp	Turing
+Corp	Oaktown Renovation
+Corp	Anonymous Tip
+Corp	Contract Killer
+Corp	Spiderweb
+Corp	Explode-A-Palooza
+Corp	Product Placement
+Corp	Bernice Mai
+Corp	Public Support
+Corp	The Cleaners
+Corp	Dedicated Response Team
+Runner	Spear Phishing
+Runner	Abagnale
+Runner	Demara
+Corp	Seidr Laboratories
+Corp	Hive
+Corp	Successful Field Test
+Corp	Shadow
+Corp	Marilyn Campaign
+Corp	Mason Bellamy
+Corp	Shipment from Kaguya
+Corp	False Lead
+Corp	Hortum
+Corp	Private Security Force
+Corp	Melange Mining Corp.
+Corp	Paper Trail
+Corp	IPO
+Runner	Stimhack
+Runner	Cyberfeeder
+Runner	Datasucker
+Runner	Ice Carver
+Runner	Gabriel Santiago
+Runner	Inside Job
+Runner	Special Order
+Runner	Femme Fatale
+Runner	Sneakdoor Beta
+Runner	Bank Job
+Runner	Diesel
+Runner	The Maker_s Eye
+Runner	Tinkering
+Runner	Aesop_s Pawnshop
+Runner	Crypsis
+Corp	Aggressive Secretary
+Corp	Heimdall 1.0
+Corp	Ichi 1.0
+Corp	Rototurret
+Corp	Archived Memories
+Corp	Biotic Labor
+Corp	Personal Evolution
+Corp	Nisei MK II
+Corp	Project Junebug
+Corp	Snare!
+Corp	Neural Katana
+Corp	Wall of Thorns
+Corp	Neural EMP
+Corp	Making News
+Corp	Ghost Branch
+Corp	Data Raven
+Corp	Tollbooth
+Corp	Closed Accounts
+Corp	SEA Source
+Corp	Red Herrings
+Corp	Building a Better World
+Corp	Hostile Takeover
+Corp	Archer
+Corp	Hadrian_s Wall
+Corp	Ice Wall
+Corp	Priority Requisition
+Corp	Hunter

--- a/card_list_council_of_the_crest.txt
+++ b/card_list_council_of_the_crest.txt
@@ -1,0 +1,20 @@
+Runner	eXer	3
+Runner	Friday Chip	3
+Runner	Crypt	3
+Corp	TechnoCo	3
+Runner	Corporate _Grant_	3
+Runner	No One Home	3
+Corp	Kuwinda K4H1U3	3
+Corp	NEXT Sapphire	3
+Corp	Anansi	3
+Corp	Code Replicator	3
+Corp	Reverse Infection	3
+Corp	Azmari EdTech - Shaping the Future	3
+Corp	Degree Mill	3
+Corp	Personalized Portal	3
+Runner	Marathon	3
+Runner	Gbahali	3
+Runner	White Hat	3
+Corp	Armed Intimidation	3
+Corp	Death and Taxes	3
+Corp	Trojan Horse	3

--- a/card_list_data_and_destiny.txt
+++ b/card_list_data_and_destiny.txt
@@ -1,0 +1,55 @@
+Runner	Adam - Compulsive Hacker	1
+Runner	Independent Thinking	3
+Runner	Brain Chip	3
+Runner	Multithreader	3
+Runner	Always Be Running	1
+Runner	Dr. Lovegood	3
+Runner	Neutralize All Threats	1
+Runner	Safety First	1
+Runner	Apex - Invasive Predator	1
+Runner	Apocalypse	3
+Runner	Prey	3
+Runner	Heartbeat	3
+Runner	Endless Hunger	3
+Runner	Harbinger	3
+Runner	Hunting Grounds	3
+Runner	Wasteland	3
+Corp	Global Food Initiative	3
+Corp	Launch Campaign	3
+Corp	Assassin	3
+Corp	SYNC - Everything, Everywhere	1
+Corp	New Angeles Sol - Your News	1
+Corp	Spark Agency - Worldwide Reach	1
+Corp	15 Minutes	3
+Corp	Improved Tracers	3
+Corp	Rebranding Team	3
+Corp	Quantum Predictive Model	3
+Corp	Lily Lockwell	3
+Corp	News Team	3
+Corp	Shannon Claire	3
+Corp	Victoria Jenkins	3
+Corp	Reality Threedee	3
+Corp	Archangel	3
+Corp	News Hound	3
+Corp	Resistor	3
+Corp	Special Offer	3
+Corp	TL_DR	3
+Corp	Turnpike	3
+Corp	24-7 News Cycle	3
+Corp	Ad Blitz	3
+Corp	Media Blitz	3
+Corp	The All-Seeing I	3
+Corp	Surveillance Sweep	3
+Corp	Keegan Lane	3
+Corp	Rutherford Grid	3
+Runner	Employee Strike	3
+Runner	Windfall	3
+Runner	Technical Writer	3
+Runner	Sunny Lebeau - Security Specialist	1
+Runner	Security Chip	3
+Runner	Security Nexus	3
+Runner	GS Striker M1	3
+Runner	GS Shrike M2	3
+Runner	GS Sherman M3	3
+Runner	Globalsec Security Clearance	3
+Runner	Jak Sinclair	3

--- a/card_list_honor_and_profit.txt
+++ b/card_list_honor_and_profit.txt
@@ -1,0 +1,55 @@
+Corp	Plan B	3
+Corp	Guard	3
+Corp	Rainbow	3
+Corp	Diversified Portfolio	3
+Corp	Fast Track	3
+Runner	Iain Sterling - Retired Spook	1
+Runner	Ken Express Tenma - Disappeared Clone	1
+Runner	Silhouette - Stealth Operative	1
+Runner	Calling in Favors	3
+Runner	Early Bird	3
+Runner	Express Delivery	3
+Runner	Feint	3
+Runner	Legwork	3
+Runner	Planned Assault	3
+Runner	Logos	3
+Runner	Public Terminal	3
+Runner	Unregistered S_W _35	3
+Runner	Window	3
+Runner	Alias	3
+Runner	Breach	3
+Runner	Bug	3
+Runner	Gingerbread	3
+Runner	Grappling Hook	3
+Runner	Passport	3
+Runner	Push Your Luck	3
+Runner	Security Testing	3
+Runner	Theophilius Bagbiter	3
+Runner	Tri-maf Contact	3
+Corp	Harmony Medtech - Biomedical Pioneer	1
+Corp	Nisei Division - The Next Generation	1
+Corp	Tennin Institute - The Secrets Within	1
+Corp	House of Knives	3
+Corp	Medical Breakthrough	3
+Corp	Philotic Entanglement	3
+Corp	The Future Perfect	3
+Corp	Chairman Hiro	3
+Corp	Mental Health Clinic	3
+Corp	Psychic Field	3
+Corp	Shi.Kyu	3
+Corp	Tenma Line	3
+Corp	Cerebral Cast	3
+Corp	Medical Research Fundraiser	3
+Corp	Mushin No Shin	3
+Corp	Inazuma	3
+Corp	Komainu	3
+Corp	Pup	3
+Corp	Shiro	3
+Corp	Susanoo-no-Mikoto	3
+Corp	NeoTokyo Grid	3
+Corp	Tori Hanzo	3
+Runner	Mass Install	3
+Runner	Q-Coherence Chip	3
+Runner	Overmind	3
+Runner	Oracle May	3
+Runner	Donut Taganes	3

--- a/card_list_misc.txt
+++ b/card_list_misc.txt
@@ -1,0 +1,28 @@
+Corp	Corp Card Back	1
+Runner	Runner Card Back	1
+Corp	PAD Campaign	3
+Corp	Enigma	3
+Corp	Adonis Campaign	3
+Runner	Ele Smoke Scovak	1
+Runner	Reina Roja	1
+Corp	Director Haas	2
+Corp	Thomas Haas	2
+Corp	Levy University	1
+Runner	The Source	1
+Runner	Wari	2
+Runner	Takobi	2
+Runner	RNG Key	2
+Runner	Aumakua	3
+Corp	Wall of Static	3
+Corp	Hedge Fund	3
+Runner	Employee Strike	3
+Runner	Dirty Laundry	3
+Corp	Rashida Jaheem	3
+Runner	Sure Gamble	3
+Corp	Vanilla	3
+Corp	Tollbooth	3
+Corp	Pop-Up Window	3
+Runner	The Turning Wheel	3
+Runner	Crowdfunding	3
+Runner	Labor Rights	3
+Runner	Daily Casts	3

--- a/card_list_order_and_chaos.txt
+++ b/card_list_order_and_chaos.txt
@@ -1,0 +1,55 @@
+Runner	Edward Kim - Humanity_s Hammer	3
+Runner	MaxX - Maximum Punk Rock	3
+Runner	Valencia Estevez - The Angel of Cayambe	3
+Runner	Amped Up	3
+Runner	I_ve Had Worse	3
+Runner	Itinerant Protesters	3
+Runner	Showing Off	3
+Runner	Wanton Destruction	3
+Runner	Day Job	3
+Runner	Forked	3
+Runner	Knifed	3
+Runner	Spooned	3
+Runner	Eater	3
+Runner	Gravedigger	3
+Runner	Hivemind	3
+Runner	Progenitor	3
+Runner	Archives Interface	3
+Runner	Chop Bot 3000	3
+Runner	MemStrips	3
+Runner	Vigil	3
+Runner	Human First	3
+Runner	Investigative Journalism	3
+Runner	Sacrificial Clone	3
+Runner	Stim Dealer	3
+Runner	Virus Breeding Ground	3
+Corp	Sub Boost	3
+Corp	Dedicated Technician Team	3
+Corp	Cyberdex Virus Suite	3
+Runner	Uninstall	3
+Runner	Qianju PT	3
+Runner	Data Folding	3
+Corp	Argus Security - Protection Guaranteed	3
+Corp	Gagarin Deep Space - Expanding the Horizon	3
+Corp	Titan Transnational - Investing In Your Future	3
+Corp	Firmware Updates	3
+Corp	Glenn Station	3
+Corp	Government Takeover	3
+Corp	High-Risk Investment	3
+Corp	Constellation Protocol	3
+Corp	Mark Yale	3
+Corp	Space Camp	3
+Corp	The Board	3
+Corp	Asteroid Belt	3
+Corp	Wormhole	3
+Corp	Nebula	3
+Corp	Orion	3
+Corp	Builder	3
+Corp	Checkpoint	3
+Corp	Fire Wall	3
+Corp	Searchlight	3
+Corp	Housekeeping	3
+Corp	Patch	3
+Corp	Traffic Accident	3
+Corp	Satellite Grid	3
+Corp	The Twins	3

--- a/card_list_order_and_chaos.txt
+++ b/card_list_order_and_chaos.txt
@@ -30,7 +30,7 @@ Runner	Uninstall	3
 Runner	Qianju PT	3
 Runner	Data Folding	3
 Corp	Argus Security - Protection Guaranteed	3
-Corp	Gagarin Deep Space - Expanding the Horizon	3
+Corp	Gagarin Deep Space - Expanding The Horizon	3
 Corp	Titan Transnational - Investing In Your Future	3
 Corp	Firmware Updates	3
 Corp	Glenn Station	3

--- a/card_list_reign_and_reverie.txt
+++ b/card_list_reign_and_reverie.txt
@@ -1,0 +1,58 @@
+Runner	Algernon	3
+Runner	Nathaniel Gnat Hall - One-of-a-Kind	1
+Runner	Divide and Conquer	3
+Runner	Guinea Pig	3
+Runner	Patchwork	3
+Runner	Hijacked Router	3
+Runner	Cradle	3
+Runner	District 99	3
+Runner	Reboot	3
+Corp	Lady Liberty	3
+Runner	Liza Talking Thunder - Prominent Legislator	1
+Runner	Hot Pursuit	3
+Runner	Paragon	3
+Runner	Bankroll	3
+Runner	Tycoon	3
+Runner	Thunder Art Gallery	3
+Runner	Miss Bones	3
+Corp	Sportsmetal - Go Big or Go Home	1
+Corp	Hyperloop Extension	3
+Corp	Meridian	3
+Corp	Gatekeeper	3
+Corp	Divert Power	3
+Corp	Fast Break	3
+Corp	Game Changer	3
+Corp	Giordano Memorial Field	3
+Corp	Saraswati Mnemonics - Endless Exploration	1
+Corp	Jumon	3
+Corp	API-S Keeper Isobel	3
+Corp	Neurostasis	3
+Corp	Otoroshi	3
+Corp	Thimblerig	3
+Corp	Hangeki	3
+Corp	Daruma	3
+Corp	Acme Consulting - The Truth You Need	1
+Corp	Fly on the Wall	3
+Corp	SIU	3
+Corp	Peeping Tom	3
+Corp	Hydra	3
+Corp	Eavesdrop	3
+Corp	Attitude Adjustment	3
+Corp	Arella Salvatore	3
+Runner	DJ Fenris	3
+Runner	Akiko Nisei - Head Case	1
+Runner	Insight	3
+Runner	Mind_s Eye	3
+Runner	Mache	3
+Runner	Ika	3
+Runner	Kyuban	3
+Runner	Psych Mike	3
+Runner	Office Supplies	3
+Corp	The Outfit - Family Owned and Operated	1
+Corp	Broad Daylight	3
+Corp	Drudge Work	3
+Corp	Blockchain	3
+Corp	Formicary	3
+Corp	Building Blocks	3
+Corp	Too Big to Fail	3
+Corp	Under the Bus	3

--- a/card_list_soverign_sight.txt
+++ b/card_list_soverign_sight.txt
@@ -1,0 +1,20 @@
+Runner	By Any Means	3
+Runner	Yusuf	3
+Runner	Assimilator	3
+Runner	Zamba	3
+Runner	Puffer	3
+Runner	Lewi Guilherme	3
+Corp	Asa Group - Security Through Vigilance	3
+Corp	Ikawah Project	3
+Corp	Najja 1.0	3
+Corp	Gene Splicer	3
+Corp	Mganga	3
+Corp	Genotyping	3
+Corp	Echo Chamber	3
+Corp	Self-Growth Program	3
+Corp	Calibration Testing	3
+Runner	Cyberdelia	3
+Runner	Upya	3
+Corp	Urban Renewal	3
+Corp	Wake Up Call	3
+Corp	Reconstruction Contract	3

--- a/card_list_system_core_2019.txt
+++ b/card_list_system_core_2019.txt
@@ -1,0 +1,135 @@
+Runner	Corroder	3
+Runner	Demolition Run	1
+Runner	Data Dealer	3
+Runner	Singularity	2
+Runner	Akamatsu Mem Chip	3
+Runner	Imp	2
+Runner	Spinal Modem	1
+Runner	Darwin	1
+Corp	Stronger Together	2
+Corp	Ash 2X3ZB9CY	2
+Runner	Hemorrhage	2
+Corp	Caduceus	1
+Runner	Notoriety	2
+Corp	Replicating Perfection	3
+Corp	Fetal AI	3
+Corp	Trick of Light	1
+Runner	Emergency Shutdown	1
+Runner	Chaos Theory	2
+Runner	Forged Activation Orders	1
+Runner	Test Run	1
+Runner	Dinosaurus	1
+Runner	Doppelganger	1
+Corp	Marked Accounts	3
+Runner	Pheromones	2
+Runner	Scrubber	1
+Runner	Crash Space	1
+Runner	Fall Guy	2
+Runner	Mr. Li	2
+Runner	Deus X	3
+Corp	Oversight AI	3
+Runner	Indexing	1
+Runner	Xanadu	2
+Runner	Networking	3
+Runner	HQ Interface	2
+Runner	Kati Jones	3
+Corp	Hokusai Grid	2
+Runner	Retrieval Run	1
+Runner	Rabbit Hole	1
+Runner	The Personal Touch	2
+Runner	R_D Interface	3
+Runner	Magnum Opus	1
+Corp	Eli 1.0	3
+Corp	Ronin	2
+Runner	All-Nighter	2
+Runner	Sacrificial Construct	2
+Runner	Infiltration	1
+Corp	Flare	2
+Runner	Underworld Contact	1
+Corp	Project Ares	1
+Corp	Hudson 1.0	2
+Corp	Shipment from MirrorMorph	2
+Corp	Strongbox	2
+Runner	Quest Completed	3
+Corp	Blue Level Clearance	3
+Corp	Yagura	2
+Corp	Wraparound	1
+Corp	Whirlpool	2
+Corp	Lotus Field	3
+Runner	Lamprey	3
+Corp	Crisium Grid	3
+Runner	Quetzal - Free Spirit	3
+Corp	Reversed Accounts	3
+Corp	Blue Sun - Powering the Future	3
+Corp	Daily Business Show	3
+Runner	Leela Patel	3
+Runner	Career Fair	3
+Corp	Turing	3
+Corp	Oaktown Renovation	3
+Corp	Anonymous Tip	2
+Corp	Contract Killer	3
+Corp	Spiderweb	3
+Corp	Explode-A-Palooza	3
+Corp	Product Placement	3
+Corp	Bernice Mai	2
+Corp	Public Support	3
+Corp	The Cleaners	2
+Corp	Dedicated Response Team	2
+Runner	Spear Phishing	3
+Runner	Abagnale	3
+Runner	Demara	3
+Corp	Seidr Laboratories	3
+Corp	Hive	1
+Corp	Successful Field Test	3
+Corp	Shadow	1
+Corp	Marilyn Campaign	3
+Corp	Mason Bellamy	3
+Corp	Shipment from Kaguya	1
+Corp	False Lead	2
+Corp	Hortum	3
+Corp	Private Security Force	1
+Corp	Melange Mining Corp.	1
+Corp	Paper Trail	3
+Corp	IPO	3
+Runner	Stimhack	2
+Runner	Cyberfeeder	1
+Runner	Datasucker	1
+Runner	Ice Carver	2
+Runner	Gabriel Santiago	2
+Runner	Inside Job	1
+Runner	Special Order	2
+Runner	Femme Fatale	1
+Runner	Sneakdoor Beta	2
+Runner	Bank Job	1
+Runner	Diesel	1
+Runner	The Maker_s Eye	2
+Runner	Tinkering	1
+Runner	Aesop_s Pawnshop	2
+Runner	Crypsis	1
+Corp	Aggressive Secretary	2
+Corp	Heimdall 1.0	2
+Corp	Ichi 1.0	1
+Corp	Rototurret	1
+Corp	Archived Memories	2
+Corp	Biotic Labor	1
+Corp	Personal Evolution	2
+Corp	Nisei MK II	1
+Corp	Project Junebug	1
+Corp	Snare!	1
+Corp	Neural Katana	2
+Corp	Wall of Thorns	2
+Corp	Neural EMP	1
+Corp	Making News	2
+Corp	Ghost Branch	2
+Corp	Data Raven	1
+Corp	Tollbooth	1
+Corp	Closed Accounts	1
+Corp	SEA Source	1
+Corp	Red Herrings	2
+Corp	Building a Better World	2
+Corp	Hostile Takeover	2
+Corp	Archer	2
+Corp	Hadrian_s Wall	2
+Corp	Ice Wall	1
+Corp	Priority Requisition	1
+Corp	Hunter	1

--- a/cleaner.ini
+++ b/cleaner.ini
@@ -6,4 +6,5 @@ catalogPath: ./cards
 InputFile: card_list.txt
 
 [configs]
-findPath: "C:\\Program Files\\Git\\usr\\bin\\find.exe"
+#findPath: "C:\\Program Files\\Git\\usr\\bin\\find.exe"
+findPath: find

--- a/cleaner.ini
+++ b/cleaner.ini
@@ -1,0 +1,9 @@
+[card-paths]
+resultPath: ./cards-complete
+catalogPath: ./cards
+
+[card-list]
+InputFile: card_list.txt
+
+[configs]
+findPath: "C:\\Program Files\\Git\\usr\\bin\\find.exe"

--- a/cleaner.py
+++ b/cleaner.py
@@ -1,8 +1,20 @@
 import subprocess
+import configparser
+
+# Read in the inventory items
+config = configparser.ConfigParser()
+config.read('cleaner.ini')
+
+result_path = config['card-paths']['ResultPath']
+catalog_path = config['card-paths']['CatalogPath']
+card_input_file = config['card-list']['InputFile']
+find_path = config['configs']['findPath']
 
 # TODO: Migrate this to be a command line arg.
-remote_image_path = "/media/nas_share/Games/Netrunner/*"
-image_path = "/home/devspringer/images"
+remote_image_path = catalog_path
+image_path = result_path
+
+print("Using the find_path of: " + find_path)
 
 if subprocess.call(["ls", image_path]) is not 0:
     print("Creating the " + image_path + " path.")
@@ -21,7 +33,7 @@ i = 1
 while i < 3:
 # Start with directories
     print("Finding candidate directories to rename.")
-    find_dir = subprocess.Popen(["find", image_path, "-type", "d", "-maxdepth", str(i), "-mindepth", str(i)], stdout=subprocess.PIPE)
+    find_dir = subprocess.Popen([find_path, image_path, "-type", "d", "-maxdepth", str(i), "-mindepth", str(i)], stdout=subprocess.PIPE)
     directories = find_dir.communicate()[0]
     print("Found: " + directories)
 
@@ -39,7 +51,7 @@ while i < 3:
 
 # Let's do the same thing for all file types.
 print("Finding candidate files to rename.")
-find_file = subprocess.Popen(["find", image_path, "-type", "f", "-mindepth", "1"], stdout=subprocess.PIPE)
+find_file = subprocess.Popen([find_path, image_path, "-type", "f", "-mindepth", "1"], stdout=subprocess.PIPE)
 files = find_file.communicate()[0]
 print("Found: " + files)
 
@@ -58,7 +70,7 @@ for file in files_list:
 
 # First, find all of the images again.
 print("Finding images to mogrify.")
-find_file = subprocess.Popen(["find", image_path, "-type", "f", "-mindepth", "1"], stdout=subprocess.PIPE)
+find_file = subprocess.Popen([find_path, image_path, "-type", "f", "-mindepth", "1"], stdout=subprocess.PIPE)
 files = find_file.communicate()[0]
 images_list = files.split('\n')
 print(images_list)

--- a/deck_assembler.ini
+++ b/deck_assembler.ini
@@ -1,0 +1,11 @@
+[card-paths]
+resultPath: ./cards
+catalogPath: ../../OneDrive/Gaming/Android-Netrunner/Cards-Original/Netrunner
+#catalogPath: "Users\Teird\OneDrive\Gaming\Android-Netrunner\Cards-Original\Netrunner"
+
+[card-list]
+InputFile: card_list.txt
+
+[configs]
+#findPath: "/c/Program Files/Git/usr/bin/find.exe"
+findPath: "find"

--- a/deck_assembler.ini
+++ b/deck_assembler.ini
@@ -1,11 +1,10 @@
 [card-paths]
 resultPath: ./cards
-catalogPath: ../../OneDrive/Gaming/Android-Netrunner/Cards-Original/Netrunner
-#catalogPath: "Users\Teird\OneDrive\Gaming\Android-Netrunner\Cards-Original\Netrunner"
+catalogPath: /media/nas_share/Games/Netrunner/
 
 [card-list]
 InputFile: card_list.txt
 
 [configs]
 #findPath: "/c/Program Files/Git/usr/bin/find.exe"
-findPath: "find"
+findPath: find

--- a/deck_assembler.py
+++ b/deck_assembler.py
@@ -1,0 +1,64 @@
+import subprocess
+import configparser
+import sys
+
+# Read in the inventory items
+config = configparser.ConfigParser()
+config.read('deck_assembler.ini')
+
+result_path = config['card-paths']['ResultPath']
+catalog_path = config['card-paths']['CatalogPath']
+card_input_file = config['card-list']['InputFile']
+find_path = config['configs']['findPath']
+
+if len(sys.argv) is 2:
+    card_input_file = sys.argv[1]
+
+print("Finding cards in " + catalog_path + " and assembling them to " + result_path)
+
+if subprocess.call(['ls', result_path]) is not 0:
+    print('Creating the ' + result_path + ' for final images')
+    subprocess.call(['mkdir', result_path])
+
+if subprocess.call(['ls', result_path + "/Corp"]) is not 0:
+    print('Creating the ' + result_path + '/Corp path for final images')
+    subprocess.call(['mkdir', result_path + "/Corp"])
+
+if subprocess.call(['ls', result_path + "/Runner"]) is not 0:
+    print('Creating the ' + result_path + '/Runner path for final images')
+    subprocess.call(['mkdir', result_path + "/Runner"])
+
+card_lines = [line.rstrip('\n') for line in open(card_input_file)]
+failed_copies = []
+failed_names = []
+
+find_process = subprocess.Popen(['C:\\Program Files\\Git\\usr\\bin\\find.exe', catalog_path, '-type', 'f'], stdout=subprocess.PIPE)
+catalog_cards_bytes = find_process.communicate()[0].decode('utf-8')
+catalog_cards = catalog_cards_bytes.splitlines()
+print('Found these catalog cards: ' + str(catalog_cards))
+
+for card_line in card_lines:
+    card_name = card_line.split('\t')[1]
+    print('Looking for card: ' + card_name)
+
+    count = 0
+    for card_path in catalog_cards:
+        if card_name + '.jpg' in card_path:
+            print('Copying from: ' + card_path)
+            print('Copying to:   ' + result_path + "/" + card_line.split('\t')[0])
+            count += 1
+            pack_name_dirty = card_path.split("/")[-2]
+            if pack_name_dirty[0].isdigit():
+                pack_name = pack_name_dirty[5:].replace(' ', '_')
+            else:
+                pack_name = pack_name_dirty.replace(' ', '_')
+            if subprocess.call(['cp', card_path, result_path + '/' + card_line.split('\t')[0] + '/' + card_name.replace(" ", "_") + '-' + str(count) + '_' + pack_name + ".jpg"]) is not 0:
+                failed_copies.append(card_path)
+                print("Failed to copy file: " + card_path + " for card name " + card_name)
+    if count is 0:
+        print("Failed to find card matching: " + str(card_name))
+        failed_names.append(card_name)
+
+print('Failed card names: ' + str(failed_names))
+
+

--- a/deck_assembler.py
+++ b/deck_assembler.py
@@ -32,7 +32,7 @@ card_lines = [line.rstrip('\n') for line in open(card_input_file)]
 failed_copies = []
 failed_names = []
 
-find_process = subprocess.Popen(['C:\\Program Files\\Git\\usr\\bin\\find.exe', catalog_path, '-type', 'f'], stdout=subprocess.PIPE)
+find_process = subprocess.Popen([find_path, catalog_path, '-type', 'f'], stdout=subprocess.PIPE)
 catalog_cards_bytes = find_process.communicate()[0].decode('utf-8')
 catalog_cards = catalog_cards_bytes.splitlines()
 print('Found these catalog cards: ' + str(catalog_cards))


### PR DESCRIPTION
This script is largely intended to make life significantly easier when assembling cards to use.  Additionally, it enables the retrieval of cards from multiple sources, allowing the user to choose which to use.

Further, the cleaner has been adapted to a new approach based upon feedback.  Now, the image boarder is a mirror image of the current card instead of black, eliminating potentially unnecessary lines.  Further, the saturation is cranked up 75% in order to make the cards pop.

There is a new, undocumented requirement to pull down a few scripts from Fred's ImageMagick repository, found here:

http://www.fmwconcepts.com/imagemagick/index.php

You need to pull in the saturation and the imageborder scripts into the bin directory to use them.